### PR TITLE
[SCRUM-57] 회원가입 이메일 인증 플로우 개선

### DIFF
--- a/src/contexts/AuthCallback.jsx
+++ b/src/contexts/AuthCallback.jsx
@@ -1,77 +1,42 @@
-// src/pages/AuthCallback.jsx
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
-import { useAuth } from '../contexts/AuthContext';
+import { useNavigate } from 'react-router-dom';
 import { supabase } from '../config/supabase';
 
 const AuthCallback = () => {
-  const [status, setStatus] = useState('처리 중...');
+  const [status, setStatus] = useState('이메일 인증 완료 중...');
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
-  const { fetchUserInfo } = useAuth();
 
   useEffect(() => {
     const handleAuth = async () => {
       try {
-        const tokenHash = searchParams.get('token_hash');
-        const type      = searchParams.get('type');
-        if (!tokenHash || !type) {
-          setStatus('잘못된 인증 링크입니다.');
-          return setTimeout(() => navigate('/signup'), 3000);
-        }
+        const { data: { session }, error } = await supabase.auth.getSession();
 
-        // 이메일 인증
-        const { data, error } = await supabase.auth.verifyOtp({
-          token_hash: tokenHash,
-          type,
-        });
-        if (error) {
-          console.error(error);
+        if (error || !session) {
           setStatus('인증에 실패했습니다.');
-          return setTimeout(() => navigate('/signup'), 3000);
+          setTimeout(() => navigate('/'), 3000);
+          return;
         }
 
-        // pendingProfile 꺼내서 INSERT
-        const pending = localStorage.getItem('pendingProfile');
-        let profile;
-        if (pending) {
-          profile = JSON.parse(pending);
-          try {
-            await supabase.from('user_info').insert(profile);
-            localStorage.removeItem('pendingProfile');
-
-            // 500ms 지연 후 fetchUserInfo 호출
-            setTimeout(async () => {
-              await fetchUserInfo(data.user.id);
-            }, 500);
-          } catch (insertErr) {
-            console.error('프로필 저장 오류:', insertErr);
-            setStatus('프로필 저장 중 오류가 발생했습니다.');
-          }
-        }
-
-        // 2초 뒤 홈으로 이동하며 이름도 state로 전달
-        setTimeout(() => {
-          navigate('/', { state: { justSignedUp: true, name: profile?.name } });
-        }, 2000);
+        setStatus('인증이 완료되었습니다');
+        setTimeout(() => navigate('/'), 3000);
 
       } catch (err) {
-        console.error(err);
+        console.error('AuthCallback 에러:', err);
         setStatus('오류가 발생했습니다.');
-        setTimeout(() => navigate('/signup'), 3000);
+        setTimeout(() => navigate('/'), 3000);
       }
     };
 
     handleAuth();
-  }, [navigate, searchParams, fetchUserInfo]);
+  }, [navigate]);
 
   return (
     <div style={{
-      display:       'flex',
+      display: 'flex',
       flexDirection: 'column',
-      alignItems:    'center',
-      justifyContent:'center',
-      height:        '100vh'
+      alignItems: 'center',
+      justifyContent: 'center',
+      height: '100vh'
     }}>
       <h2>이메일 인증</h2>
       <p>{status}</p>

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,80 +1,54 @@
 import { createContext, useContext, useState, useEffect } from 'react';
 import { supabase } from '../config/supabase';
 
-// 사용자 정보를 저장할 전역 상자
 const AuthContext = createContext()
 
-// 다른 컴포넌트에서 상자에서 데이터 꺼내기
 export const useAuth = () => {
   return useContext(AuthContext)
 }
 
-// 저장소제공자
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null)
-  const [userInfo, setUserInfo] = useState(null) // 사용자 정보 상태
+  const [userInfo, setUserInfo] = useState(null)
   const [loading, setLoading] = useState(true)
 
-  console.log('AuthProvider 렌더링 - loading:', loading)
-  console.log('현재 환경:', {
-     origin: window.location.origin,
-     supabaseUrl: import.meta.env.VITE_SUPABASE_URL,
-     production: import.meta.env.PROD
-   });
-
-  // 인증 상태 변화 감지 추가
   useEffect(() => {
-    console.log('useEffect 시작')
     const getSession = async () => {
       try {
-        console.log('세션 및 사용자 정보 조회 시작')
-
-        // 1. 세션 확인
+        // 세션 확인
         const { data: { session } } = await supabase.auth.getSession()
-        console.log('세션 결과:', session)
-
         setUser(session?.user ?? null)
 
-        // 2. 로그인 상태면 user_info도 가져오기
         if (session?.user) {
-          console.log('사용자 정보 조회 시작 - userId:', session.user.id)
-
-          //await fetchUserInfo(session.user.id)
           const { data, error } = await supabase
             .from('user_info')
             .select('name, points_balance, role, profile_image, notification_settings')
-            .eq('id', session.user.id) // UUID로 조회
+            .eq('id', session.user.id)
             .single()
 
           if (error) {
             console.error('사용자 정보 조회 에러:', error)
             setUserInfo(null)
           } else {
-            console.log('사용자 정보 조회 성공:', data)
             setUserInfo(data)
-
           }
         } else {
-          console.log('로그인 상태 아님 - userInfo null로 설정')
           setUserInfo(null)
         }
       } catch (error) {
-        console.error('getSessionAndUser 에러:', error)
+        console.error('세션 조회 에러:', error)
       } finally {
-        // 3. 성공/실패 관계없이 loading 완료
-        console.log('모든 작업 완료 - loading을 false로 설정')
         setLoading(false)
       }
     }
-    getSession() // 즉시 실행
+
+    getSession()
 
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
       (_event, session) => {
-        console.log('인증 상태 변화:', _event, session?.user?.email)
         setUser(session?.user ?? null)
 
         if (session?.user) {
-          console.log('로그인 감지 - fetchUserInfo 호출')
           fetchUserInfo(session.user.id)
         } else {
           setUserInfo(null)
@@ -84,15 +58,11 @@ export const AuthProvider = ({ children }) => {
       }
     )
 
-
-
     return () => {
-      console.log('subscription 해제')
       subscription.unsubscribe()
     }
   }, [])
 
-  // user_id로 user_info 테이블에서 사용자 정보 가져오기
   const fetchUserInfo = async (userId) => {
     try {
       const { data, error } = await supabase
@@ -110,23 +80,27 @@ export const AuthProvider = ({ children }) => {
       console.error('사용자 정보 조회 실패:', error)
     }
   }
-  //회원가입 함수
+  //회원가입
   const signUp = async (email, password, userData) => {
     try {
-      console.log('회원가입 시도:', { email, userData });
       const { data, error } = await supabase.auth.signUp({
         email,
         password,
         options: {
-          emailRedirectTo: `${window.location.origin}/auth/callback`
+          emailRedirectTo: `${window.location.origin}/auth/callback`,
+          data: {
+            user_id: userData.user_id,
+            name: userData.name,
+            phone: userData.phone,
+          }
         }
       });
+
       if (error) {
         alert('회원가입 실패: ' + error.message);
         return { success: false, error };
       }
 
-      // INSERT 대신, 로컬에 pendingProfile만 저장
       const profileData = {
         id: data.user.id,
         user_id: userData.user_id,
@@ -135,24 +109,24 @@ export const AuthProvider = ({ children }) => {
         phone: userData.phone,
         address: userData.address || null,
         birth_date: userData.birth_date || null,
-        // 테이블 수정 후 추가한 필드
         profile_image: 'default.png',
         points_balance: 0,
         role: 'user',
-        //테이블에 DEFAULT 값이 있지만, 명시적으로 값을 넣지 않으면 INSERT 시 문제가 생길 수 있음
-        // 테이블에서 not null()
-        notification_settings: {
-          "shipping": true, //  배송 관련 알림
-          "marketing": false, // 광고 알링
-          "order_status": true, // 주문 상태 알림
-          "product_restock": true, // 상품 재입고 알림
-          "product_discount": true // 상품 할인 알림
-        }
       };
-      localStorage.setItem('pendingProfile', JSON.stringify(profileData));
 
-      alert('이메일을 확인하고, 인증 링크를 클릭해야 회원가입이 완료됩니다!');
+      const { error: insertError } = await supabase
+        .from('user_info')
+        .insert(profileData);
+
+      if (insertError) {
+        console.error('user_info 삽입 실패:', insertError);
+        alert('회원가입 처리 중 오류가 발생했습니다.');
+        return { success: false, error: insertError };
+      }
+
+      alert('이메일을 확인하고, 인증 링크를 클릭해주세요!');
       return { success: true, data };
+
     } catch (error) {
       console.error('회원가입 에러:', error);
       alert('회원가입 중 오류가 발생했습니다.');
@@ -160,7 +134,7 @@ export const AuthProvider = ({ children }) => {
     }
   }
 
-  // 로그인 함수
+  // 로그인
   const signIn = async (email, password) => {
     try {
       const { data, error } = await supabase.auth.signInWithPassword({
@@ -170,11 +144,10 @@ export const AuthProvider = ({ children }) => {
       if (error) {
         alert('로그인 실패: ' + error.message)
         return { success: false, error }
-      } else {
-        // setUser는 onAuthStateChange에서 자동으로 처리됨
-        alert('로그인 성공')
-        return { success: true, data }
       }
+
+      alert('로그인 성공')
+      return { success: true, data }
     } catch (error) {
       console.error('로그인 에러:', error)
       alert('로그인 중 오류가 발생했습니다.')
@@ -182,16 +155,15 @@ export const AuthProvider = ({ children }) => {
     }
   }
 
-  // 로그아웃 함수
+  // 로그아웃
   const signOut = async () => {
     try {
       const { error } = await supabase.auth.signOut()
       if (error) {
         alert('로그아웃 실패: ' + error.message)
         return { success: false, error }
-      } else {
-        return { success: true }
       }
+      return { success: true }
     } catch (error) {
       console.error('로그아웃 에러:', error)
       alert('로그아웃 중 오류가 발생했습니다.')
@@ -206,13 +178,12 @@ export const AuthProvider = ({ children }) => {
     signUp,
     signIn,
     signOut,
-    fetchUserInfo // 다름 컴포넌트에서 정보 갱신 필요할 때 사용
+    fetchUserInfo
   }
 
   return (
     <AuthContext.Provider value={value}>
       {!loading && children}
-      {/* 로딩이 완료된 후에만 자식 컴포넌트 렌더링 */}
     </AuthContext.Provider>
   )
 }


### PR DESCRIPTION
## 문제점
- localStorage의 pendingProfile이 이메일 인증 시 새 탭에서 접근 불가
- 이메일 인증 후 user_info 테이블 삽입이 실패하여 로그인 불가
- AuthCallback에서 URL hash의 token_hash 파싱 실패

## 해결 방법
- 회원가입 시점에 auth.users와 user_info를 동시에 생성
- localStorage 의존성 완전 제거
- AuthCallback은 세션 확인 후 메인 페이지 리다이렉트만 수행

## 변경 사항
### AuthContext.jsx
- `signUp` 함수에서 회원가입과 동시에 user_info INSERT
- 불필요한 console.log 및 주석 정리

### AuthCallback.jsx
- URL 파라미터 파싱 로직 제거
- 세션 확인 후 메인 페이지로 리다이렉트
- 로직 단순화

## 테스트
- [x] 회원가입 시 user_info 정상 삽입 확인
- [x] 이메일 인증 링크 클릭 시 정상 리다이렉트
- [x] user_id로 로그인 정상 작동